### PR TITLE
fix: corrección de preguntas y explicación

### DIFF
--- a/src/data/asignaturas/itinerarioParaLaEmpleabilidad/modulos/importanteExamen.js
+++ b/src/data/asignaturas/itinerarioParaLaEmpleabilidad/modulos/importanteExamen.js
@@ -368,7 +368,7 @@ export const importanteExamen = {
       ],
       respuestaCorrecta: 1,
       explicacion:
-        "Podemos encontrar la clasifiación del cuadro de enfermades profesionales en el Real Decreto 1299/2006, de 10 de noviembre, por el que se aprueba el cuadro de enfermedades profesionales en el sistema de la Seguridad Social y se establecen criterios para su notificación y registro.",
+        "Los principios de la citada ley podemos se encuentran en el artículo 15 (Ley 31/1995, de 8 de noviembre, de Prevención de Riesgos Laborales).",
     },
     {
       id: 6626,
@@ -378,12 +378,12 @@ export const importanteExamen = {
       opciones: [
         "Combatir los riesgos en su origen.",
         "Evaluar los riesgos que se puedan evitar.",
-        "Combatir los riesgos en su origen.",
+        "Combatir los riesgos una vez desaparecido el peligro.",
         "Adaptar la persona al trabajo.",
       ],
       respuestaCorrecta: 0,
       explicacion:
-        "Podemos encontrar la clasifiación del cuadro de enfermades profesionales en el Real Decreto 1299/2006, de 10 de noviembre, por el que se aprueba el cuadro de enfermedades profesionales en el sistema de la Seguridad Social y se establecen criterios para su notificación y registro.",
+        "Los principios de la citada ley podemos se encuentran en el artículo 15 (Ley 31/1995, de 8 de noviembre, de Prevención de Riesgos Laborales).",
     },
     {
       id: 6627,
@@ -398,7 +398,7 @@ export const importanteExamen = {
       ],
       respuestaCorrecta: 0,
       explicacion:
-        "Podemos encontrar la clasifiación del cuadro de enfermades profesionales en el Real Decreto 1299/2006, de 10 de noviembre, por el que se aprueba el cuadro de enfermedades profesionales en el sistema de la Seguridad Social y se establecen criterios para su notificación y registro.",
+        "Los principios de la citada ley podemos se encuentran en el artículo 15 (Ley 31/1995, de 8 de noviembre, de Prevención de Riesgos Laborales).",
     },
     {
       id: 6628,
@@ -413,7 +413,7 @@ export const importanteExamen = {
       ],
       respuestaCorrecta: 0,
       explicacion:
-        "Podemos encontrar la clasifiación del cuadro de enfermades profesionales en el Real Decreto 1299/2006, de 10 de noviembre, por el que se aprueba el cuadro de enfermedades profesionales en el sistema de la Seguridad Social y se establecen criterios para su notificación y registro.",
+        "Los principios de la citada ley podemos se encuentran en el artículo 15 (Ley 31/1995, de 8 de noviembre, de Prevención de Riesgos Laborales).",
     },
     {
       id: 6629,
@@ -428,7 +428,7 @@ export const importanteExamen = {
       ],
       respuestaCorrecta: 0,
       explicacion:
-        "Podemos encontrar la clasifiación del cuadro de enfermades profesionales en el Real Decreto 1299/2006, de 10 de noviembre, por el que se aprueba el cuadro de enfermedades profesionales en el sistema de la Seguridad Social y se establecen criterios para su notificación y registro.",
+        "Los principios de la citada ley podemos se encuentran en el artículo 15 (Ley 31/1995, de 8 de noviembre, de Prevención de Riesgos Laborales).",
     },
     {
       id: 6630,
@@ -443,7 +443,7 @@ export const importanteExamen = {
       ],
       respuestaCorrecta: 0,
       explicacion:
-        "Podemos encontrar la clasifiación del cuadro de enfermades profesionales en el Real Decreto 1299/2006, de 10 de noviembre, por el que se aprueba el cuadro de enfermedades profesionales en el sistema de la Seguridad Social y se establecen criterios para su notificación y registro.",
+        "Los principios de la citada ley podemos se encuentran en el artículo 15 (Ley 31/1995, de 8 de noviembre, de Prevención de Riesgos Laborales).",
     },
     {
       id: 6631,
@@ -458,7 +458,7 @@ export const importanteExamen = {
       ],
       respuestaCorrecta: 0,
       explicacion:
-        "Podemos encontrar la clasifiación del cuadro de enfermades profesionales en el Real Decreto 1299/2006, de 10 de noviembre, por el que se aprueba el cuadro de enfermedades profesionales en el sistema de la Seguridad Social y se establecen criterios para su notificación y registro.",
+        "Los principios de la citada ley podemos se encuentran en el artículo 15 (Ley 31/1995, de 8 de noviembre, de Prevención de Riesgos Laborales).",
     },
     {
       id: 6632,
@@ -473,7 +473,7 @@ export const importanteExamen = {
       ],
       respuestaCorrecta: 0,
       explicacion:
-        "Podemos encontrar la clasifiación del cuadro de enfermades profesionales en el Real Decreto 1299/2006, de 10 de noviembre, por el que se aprueba el cuadro de enfermedades profesionales en el sistema de la Seguridad Social y se establecen criterios para su notificación y registro.",
+        "Los principios de la citada ley podemos se encuentran en el artículo 15 (Ley 31/1995, de 8 de noviembre, de Prevención de Riesgos Laborales).",
     },
     {
       id: 6633,
@@ -488,7 +488,7 @@ export const importanteExamen = {
       ],
       respuestaCorrecta: 0,
       explicacion:
-        "Podemos encontrar la clasifiación del cuadro de enfermades profesionales en el Real Decreto 1299/2006, de 10 de noviembre, por el que se aprueba el cuadro de enfermedades profesionales en el sistema de la Seguridad Social y se establecen criterios para su notificación y registro.",
+        "Los principios de la citada ley podemos se encuentran en el artículo 15 (Ley 31/1995, de 8 de noviembre, de Prevención de Riesgos Laborales).",
     },
     {
       id: 6634,
@@ -503,7 +503,7 @@ export const importanteExamen = {
       ],
       respuestaCorrecta: 0,
       explicacion:
-        "Podemos encontrar la clasifiación del cuadro de enfermades profesionales en el Real Decreto 1299/2006, de 10 de noviembre, por el que se aprueba el cuadro de enfermedades profesionales en el sistema de la Seguridad Social y se establecen criterios para su notificación y registro.",
+        "Los principios de la citada ley podemos se encuentran en el artículo 15 (Ley 31/1995, de 8 de noviembre, de Prevención de Riesgos Laborales).",
     },
   ],
 };


### PR DESCRIPTION
# Corrección de Issue
## Issue relacionado
Fixes #128

## Tipo de corrección
- [x] Error tipográfico o de contenido
- [ ] Corrección de bug crítico
- [ ] Corrección de bug menor
- [ ] Problema de UI/UX
- [ ] Problema de rendimiento
- [ ] Otro:

## Problema original
El problema consistía en:
- Opciones duplicadas en la pregunta con ID 6626 (la opción "Combatir los riesgos en su origen" aparecía dos veces)
- Explicaciones incorrectas en las preguntas 6626-6634, que hacían referencia al Real Decreto 1299/2006 sobre enfermedades profesionales, cuando debían referirse a la Ley 31/1995 de Prevención de Riesgos Laborales.

## Solución implementada
La solución consiste en:
1. Modificar la pregunta 6626 para eliminar la opción duplicada y reemplazarla con una opción diferente
2. Corregir las explicaciones de las preguntas 6626-6634 para que hagan referencia correctamente al artículo 15 de la Ley 31/1995 de Prevención de Riesgos Laborales

## Causa raíz
El problema fue causado por:
- Error al copiar y pegar el contenido, provocando la duplicación de opciones
- Reutilización incorrecta de la explicación de las preguntas sobre enfermedades profesionales en las preguntas sobre principios de la Ley de PRL

## Impacto de la corrección
- **Componentes afectados**: Módulo de examen con ID 606 "Preguntas importantes (Tema 1 temporal)"
- **Posibles efectos secundarios**: Ninguno. Las correcciones sólo afectan al contenido de las preguntas, no a la funcionalidad.

## Capturas de pantalla / Videos
N/A - Cambios en datos, no en interfaz visual

## Cómo reproducir el problema original
1. Acceder al módulo de examen con ID 606
2. Observar la pregunta con ID 6626 donde "Combatir los riesgos en su origen" aparece duplicado
3. Revisar las explicaciones de las preguntas 6626-6634 que hacen referencia incorrecta al RD 1299/2006

## Cómo probar la corrección
1. Acceder al módulo de examen con ID 606
2. Verificar que la pregunta 6626 ya no tiene opciones duplicadas
3. Comprobar que las explicaciones de las preguntas 6626-6634 ahora hacen referencia correcta a la Ley 31/1995

## Lista de verificación
- [x] He verificado que la corrección no introduce nuevos problemas
- [x] He documentado los cambios necesarios
- [x] El problema no reaparece bajo diferentes condiciones
- [ ] He añadido o actualizado pruebas que confirman que la corrección funciona
- [ ] Todos los tests pasan en mi entorno local
- [ ] He probado la solución en diferentes navegadores/dispositivos