### PR TITLE
[BUG] Tiempo de toast se reinicia al crear nuevos 

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -86,7 +86,7 @@ define(['./workbox-84006cf1'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.j5mk5mci488"
+    "revision": "0.iams6vribdo"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/components/common/Toast.jsx
+++ b/src/components/common/Toast.jsx
@@ -8,26 +8,29 @@
  * @param {string} [props.type='info'] - Tipo de toast ('success', 'error', 'warning', 'info')
  * @param {number} [props.duration=3000] - Duración en milisegundos
  * @param {Function} props.onClose - Función para cerrar el toast
+ * @param {number} props.createdAt - Timestamp de creación del toast
  * @returns {JSX.Element} Componente Toast renderizado
  */
 import React, { useEffect, useState, useRef } from 'react';
 import { useTheme, useDeviceType } from '@hooks';
 import { SAFE_COLORS, COMPONENT_COLORS } from '@styles/safeStyles';
 
-export default function Toast({ message, type = 'info', duration = 3000, onClose }) {
+export default function Toast({ message, type = 'info', duration = 3000, onClose, createdAt }) {
   const { darkMode } = useTheme();
   const { isMobile } = useDeviceType();
   const [timeLeft, setTimeLeft] = useState(duration);
   const intervalRef = useRef(null);
-  const startTimeRef = useRef(Date.now());
 
   // Efecto para el tiempo restante y cerrar automáticamente
   useEffect(() => {
-    startTimeRef.current = Date.now();
+    // Calcular tiempo restante inicial basado en el momento de creación
+    const initialElapsed = Date.now() - createdAt;
+    const initialRemaining = Math.max(0, duration - initialElapsed);
+    setTimeLeft(initialRemaining);
 
     // Actualizar el tiempo restante cada 16ms (60fps)
     intervalRef.current = setInterval(() => {
-      const elapsedTime = Date.now() - startTimeRef.current;
+      const elapsedTime = Date.now() - createdAt;
       const remaining = Math.max(0, duration - elapsedTime);
       setTimeLeft(remaining);
 
@@ -41,7 +44,7 @@ export default function Toast({ message, type = 'info', duration = 3000, onClose
     return () => {
       clearInterval(intervalRef.current);
     };
-  }, [duration, onClose]);
+  }, [duration, onClose, createdAt]);
 
   // Mapeo de tipo de toast a componente de colores seguros
   const getTypeComponent = () => {

--- a/src/components/common/ToastContainer.jsx
+++ b/src/components/common/ToastContainer.jsx
@@ -28,7 +28,9 @@ const toastManager = {
   // Añadir un nuevo toast
   add(message, type = 'info', duration = 3000) {
     const id = ++toastId;
-    this.toasts.push({ id, message, type, duration });
+    // Agregar timestamp de creación para seguimiento del progreso
+    const createdAt = Date.now();
+    this.toasts.push({ id, message, type, duration, createdAt });
     this.notifyListeners();
     return id;
   },
@@ -90,6 +92,7 @@ export default function ToastContainer() {
           message={toast.message}
           type={toast.type}
           duration={toast.duration}
+          createdAt={toast.createdAt}
           onClose={() => handleClose(toast.id)}
         />
       ))}


### PR DESCRIPTION
# Corrección de Issue

<!-- Proporciona un resumen del problema que estás solucionando -->
Al tener más de un toast en pantalla el tiempo de desaparición de los anteriores se reinicia para estar sincronizado con el último, 
Interesa que cada toast tenga su tiempo independiente. 



## Tipo de corrección

<!-- Marca con una "x" la opción más relevante -->

- [ ] Corrección de bug crítico
- [ ] Corrección de bug menor
- [ ] Error tipográfico o de contenido
- [x] Problema de UI/UX
- [ ] Problema de rendimiento
- [ ] Otro: <!-- especifica -->

## Problema original

<!-- Describe brevemente el problema que existía -->

El problema consistía en: El toast gestionaba el tiempo de desaparición en conjunto y no por toast individual. 

<!-- Describe el comportamiento incorrecto -->

## Solución implementada

<!-- Describe en detalle la solución que has implementado -->

La solución consiste en:

<!-- Describe los cambios realizados y cómo solucionan el problema -->

## Causa raíz

<!-- Si es aplicable, explica la causa raíz del problema -->

El problema fue causado por:

<!-- Explica qué causó el problema originalmente -->

## Impacto de la corrección

<!-- Indica qué partes de la aplicación podrían verse afectadas por este cambio -->

- **Componentes afectados**: <!-- listar --> Toast.jsx ToastContainer.jsx toastUtils.js
- **Posibles efectos secundarios**: <!-- si los hay --> N/A


## Cómo probar la corrección

<!-- Pasos detallados para verificar que la corrección funciona correctamente -->


1. <!-- Paso 1 --> Genera varios test favoritos rápidos
2. <!-- Paso 2 --> Comprueba que cada uno tiene su propio tiempo de desaparición


## Lista de verificación

<!-- Marca con una "x" los puntos completados -->

- [x] He añadido o actualizado pruebas que confirman que la corrección funciona
- [x] Todos los tests pasan en mi entorno local
- [x] He documentado los cambios necesarios (si aplica)
- [x] He verificado que la corrección no introduce nuevos problemas
- [x] He probado la solución en diferentes navegadores/dispositivos (si aplica)
- [x] El problema no reaparece bajo diferentes condiciones o estados de la aplicación

